### PR TITLE
Added entry for -mconly flag for setup tool

### DIFF
--- a/sphinx/source/setup.rst
+++ b/sphinx/source/setup.rst
@@ -831,6 +831,7 @@ it hasn't already been done so by an earlier invocation.
 library specified by one the Config files traversed by the setup
 tool. 
 
+*-mconly* forces the setup tool to only run the macro processor.
 
 
 .. _`Sec:SetupShortcuts`:

--- a/sphinx/source/setup.rst
+++ b/sphinx/source/setup.rst
@@ -831,7 +831,8 @@ it hasn't already been done so by an earlier invocation.
 library specified by one the Config files traversed by the setup
 tool. 
 
-*-mconly* forces the setup tool to only run the macro processor.
+*-mconly* forces the setup tool to only run the macro processor. Processed files
+are saved to the object directory.
 
 
 .. _`Sec:SetupShortcuts`:


### PR DESCRIPTION
This PR adds a short entry into `setup.rst` for the recently added `-mconly` flag option in the setup tool.